### PR TITLE
商品詳細マークアップ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,5 +2,6 @@
 @import "modules/homes/header";
 @import "modules/homes/body";
 @import "modules/homes/footer";
+@import "modules/items/show";
 @import "font-awesome-sprockets";
 @import "font-awesome";

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the items controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/modules/items/show.scss
+++ b/app/assets/stylesheets/modules/items/show.scss
@@ -1,0 +1,317 @@
+* {
+  box-sizing: border-box;
+}
+
+// item-box__tableのth用
+@mixin table-th {
+  width: 152px;
+  background-color: #eee;
+  font-weight: 400;
+  padding: 8px;
+  border: 1px solid #dedede;
+  font-size: 14px;
+  text-align: center;
+}
+
+// item-box__tableのtd用
+@mixin table-td {
+  width: 467px;
+  padding: 15px 15px;
+  border: 1px solid #dedede;
+  font-size: 14px;
+}
+
+// item-box__optionとlinksのicon用
+@mixin icon {
+  display: inline-block;
+  font-size: 14px;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+}
+
+.main-show {
+  font-family: "Source Sans Pro", Helvetica, Arial, "游ゴシック体", "YuGothic", "メイリオ", "Meiryo", sans-serif;
+  background-color: #f8f8f8;
+  padding: 40px;
+  margin: 0 auto;
+}
+
+.item-content {
+  width: 700px;
+  margin: 0 auto;
+}
+
+.item-box {
+  background-color: #fff;
+  padding: 24px 40px 40px;
+
+  &__name {
+    h2 {
+      text-align: center;
+      font-weight: bold;
+      font-size: 24px;
+    }
+  }
+
+  &__body {
+    margin-top: 16px;
+  }
+
+  &__price {
+    margin: 24px 0 24px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+
+    &--yen {
+      font-size: 46px;
+      font-weight: bold;
+      margin: 0 10px 0 0;
+      text-align: center;
+    }
+  }
+
+  &__price-detail {
+    font-size: 16px;
+    text-align: center;
+  }
+
+  &__text {
+    line-height: 1.5;
+    font-size: 18px;
+    margin-bottom: 30px;
+
+  }
+
+  &__table {
+    margin-bottom: 20px;
+
+    &--tbody {
+      width: 100%;
+      height: 375px;
+      border-collapse: collapse;
+      border: 1px solid #f8f8f8;
+      border-spacing: 0;
+      display: table-row-group;
+      vertical-align: middle;
+      border-color: inherit;
+
+      table {
+        width: 100%;
+        height: 375px;
+        border-collapse: collapse;
+        border: 1px solid #f8f8f8;
+        border-spacing: 0;
+
+        tr {
+          display: table-row;
+          vertical-align: inherit;
+          border-color: inherit;
+          border-collapse: collapse;
+
+          th {
+            @include table-th
+          }
+
+          td {
+            @include table-td
+          }
+
+          a {
+            text-decoration: none;
+            color: #3CCACE;
+          }
+        }
+      }
+    }
+  }
+
+  &__option {
+    display: flex;
+    justify-content: space-between;
+
+    &--ul {
+      margin: 10px 0 0;
+      display: flex;
+      list-style: none;
+    }
+  }
+
+  &__like-btn {
+    margin-right: auto;
+    padding: 6px 10px;
+    border-radius: 40px;
+    color: #3CCACE;
+    border: 1px solid #ffb340;
+
+    &--icon {
+      @include icon
+    }
+  }
+
+  &__unsuitable {
+    margin: 10px 0 0;
+    display: flex;
+  }
+
+  &__unsuitable-btn {
+    font-size: 14px;
+
+    a {
+      padding: 6px 10px;
+      display: inline-block;
+      border-radius: 4px;
+      color: #333;
+      border: 1px solid #333;
+      text-decoration: none;
+    }
+
+    &--icon {
+      @include icon
+    }
+  }
+}
+
+.main-body-ul {
+  display: flex;
+  position: relative;
+  list-style: none;
+}
+
+.main-body-li {
+  display: flex;
+  flex-direction: column;
+  width: 560px;
+  align-items: center;
+  margin: 0 auto;
+
+  &__img {
+    object-fit: cover;
+    height: 346px;
+    width: 100%;
+    vertical-align: bottom;
+  }
+}
+
+.sub-body-ul {
+  display: flex;
+  justify-content: center;
+  margin-top: 10px;
+  display: flex;
+  position: relative;
+  list-style: none;
+}
+
+.sub-body-li {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  &__img {
+    margin: 0 10px 0 0;
+    object-fit: cover;
+    height: 87px;
+    width: 140px;
+    vertical-align: bottom;
+  }
+}
+
+.links {
+  padding-top: 10px;
+  width: 700px;
+  margin: 0 auto;
+  list-style: none;
+  margin-bottom: 24px;
+
+  &__front {
+    float: left;
+  }
+
+  &__back {
+    float: right;
+  }
+
+  a {
+    text-decoration: none;
+    color: #3CCACE;
+  }
+
+}
+
+.lists-box {
+  width: 700px;
+  height: 350px;
+  margin: 0 auto;
+  padding-top: 24px;
+}
+
+.see-more {
+  display: block;
+  margin-bottom: 8px;
+  color: #3CCACE;
+  text-decoration: none;
+  font-weight: bold;
+  font-size: 22px;
+  position: relative;
+}
+
+.item-list {
+  margin: 0 0 10px;
+  float: left;
+  width: calc(100% / 3);
+  height: 277px;
+
+  a {
+    display: block;
+    margin: 24px 0 8px;
+    color: #3CCACE;
+    text-decoration: none;
+    font-weight: bold;
+    font-size: 22px;
+  }
+
+  &__head {
+    background-color: #fff;
+    width: 220px;
+    height: 150px;
+    overflow: hidden;
+    z-index: auto;
+
+    &--img {
+      width: 100%;
+      z-index: auto;
+      height: 150px;
+      object-fit: cover;
+    }
+  }
+
+  &__body {
+    background-color: white;
+    color: #333;
+    padding: 16px;
+    height: 95px;
+
+    &--name {
+      overflow: hidden;
+      line-height: 1.5;
+      font-size: 16px;
+      text-align: left;
+    }
+
+    &--text {
+      font-size: 16px;
+
+      ul {
+        list-style: none;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      p {
+        font-size: 10px;
+        text-align: left;
+      }
+    }
+  }
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,7 @@
 class ItemsController < ApplicationController
   def index
   end
+
+  def show
+  end
 end

--- a/app/views/items/_table.html.haml
+++ b/app/views/items/_table.html.haml
@@ -1,0 +1,49 @@
+.item-box__table
+  .item-box__table--tbody
+    %table
+      %tr
+        %th
+          出品者
+        %td
+          hoge
+      %tr
+        %th
+          カテゴリー
+        %td
+          = link_to '#' do
+            ベビー・キッズ
+          %br/
+          = link_to '#' do
+            ベビー服(男女兼用)  ~95cm
+          %br/
+          = link_to '#' do
+            アウター
+      %tr
+        %th
+          ブランド
+        %td
+      %tr
+        %th
+          商品のサイズ
+        %td
+      %tr
+        %th
+          商品の状態
+        %td
+          未使用に近い
+      %tr
+        %th
+          配送料の負担
+        %td
+          送料込み（出品者負担）
+      %tr
+        %th
+          発送元の地域
+        %td
+          = link_to '#' do
+            岩手県
+      %tr
+        %th
+          発送日の目安
+        %td
+          4-7日で発送

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,0 +1,76 @@
+= render 'homes/header'
+
+.main-show
+  .item-content
+    .item-box
+      .item-box__name
+        %h2
+          product3
+      .item-box__body
+        %ul.main-body-ul
+          %li.main-body-li
+            = image_tag 'https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png', class: 'main-body-li__img'
+            %ul.sub-body-ul
+              %li.sub-body-li
+                = image_tag 'https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png', class: 'sub-body-li__img'
+              %li
+                = image_tag 'https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/14/a001.png', class: 'sub-body-li__img'
+              %li
+                = image_tag 'https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/15/a003.png', class: 'sub-body-li__img'
+
+      .item-box__price
+        %span.item-box__price--yen
+          ¥30000
+        .item-box__price-detail
+          %span
+            (税込)
+          %span
+            送料込み
+      .item-box__text
+        親譲りの無鉄砲で小供の時から損ばかりしている。小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした事がある。なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由でもない。新築の二階から首を出していたら、同級生の一人が冗談に、いくら威張っても、そこから飛び降りる事は出来まい。弱虫やーい。と囃したからである。小使に負ぶさって帰って来た時、おやじが大きな眼をして二階ぐらいから飛び降りて腰
+      = render 'table'
+      .item-box__option
+        %ul.item-box__option--ul
+          %li.item-box__like-btn
+            .item-box__like-btn--icon
+              = icon('fas','star')
+            お気に入り 0
+        %ul.item-box__option--ul
+          %li.item-box__unsuitable-btn
+            = link_to '#', class:'item-box__unsuitable-btn--icon' do
+              = icon('fas','flag')
+              不適切な商品の通報
+
+  .comment-box
+  %ul.links
+    %li.links__front
+      = link_to '#',class:'links__front--icon' do
+        = icon('fas','angle-left')
+        %span
+        前の商品
+    %li.links__back
+      = link_to '#',class:'links__back--icon' do
+        %span
+        後ろの商品
+        = icon('fas','angle-right')
+
+  .lists-box
+    = link_to '#', class:'see-more' do
+      ベビー・キッズをもっと見る
+    .item-lists
+      .item-list
+        = link_to '#' do
+          .item-list__head
+            = image_tag 'https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/16/IMG_9072.JPG', class: 'item-list__head--img'
+          .item-list__body
+            .item-list__body--name
+              %h3 ee
+            .item-list__body--text
+              %ul
+                %li 1000円
+                %li
+                  = icon('fas','star')
+                  0
+              %p (税込)
+
+= render 'homes/footer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   root 'homes#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  resources :items, only: [:index, :show]
   devise_for :users
 end


### PR DESCRIPTION
This reverts commit 0e950bccc1b6fdc5366eb07704b6bbf5286c7098.

このプルリクエストは誤ってマージしてしまった(#13)を打ち消した(#16)後の再プルリクエスト(#17)です。

# What
商品をクリックした際の商品の詳細ページを作成した。

# Why
一覧画面からより詳細な商品情報を必要とするため。
サーバーサイドに移る前にマークアップで画面遷移を想定しやすくするため。

# Image
<img width="1440" alt="スクリーンショット 2020-07-03 17 26 11" src="https://user-images.githubusercontent.com/59369094/86454133-c6024d00-bd59-11ea-8845-4d51e04766fe.png">
<img width="1440" alt="スクリーンショット 2020-07-03 17 26 25" src="https://user-images.githubusercontent.com/59369094/86454142-cac70100-bd59-11ea-8e80-ba5bd3c415e9.png">
<img width="1440" alt="スクリーンショット 2020-07-03 17 26 31" src="https://user-images.githubusercontent.com/59369094/86454146-cb5f9780-bd59-11ea-8f59-e4fab948c7d4.png">