### PR TITLE
Delete 20200707014731_create_item_images.rb

### DIFF
--- a/db/migrate/20200707014731_create_item_images.rb
+++ b/db/migrate/20200707014731_create_item_images.rb
@@ -1,9 +1,0 @@
-class CreateItemImages < ActiveRecord::Migration[6.0]
-  def change
-    create_table :item_images do |t|
-      t.string :image,    null: false
-      t.references :item, null: false, foreign_key: true
-      t.timestamps
-    end
-  end
-end


### PR DESCRIPTION
# What
migrateエラー解消のため表題のマイグレーションファイルを削除した。

# Why
マイグレーションファイルの内容に重複があったため解消する必要があった。