### PR TITLE
[WIP]add_category_form_in_sell_page

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,0 +1,89 @@
+$(function(){
+  // ボックスのオプション
+  function appendOption(category){
+    var html =`<option value="${category.id}" data-category="${category.id}">${category.name}</option>`;
+    return html;
+  }
+  // 子カテゴリー表示のHTML
+  function appendChildrenBox(insertHTML){
+    // 一旦初期化
+    var childSelectHTML = ''
+    childSelectHTML = `<div class='listing-select-wrapper__added' id= 'children_wrapper'>
+                        <div class='listing-select-wrapper__box'>
+                          <select class="listing-select-wrapper__box--select" id="child_category" name="item[category_id]">
+                            <option value="選択して下さい" data-category="選択して下さい">選択して下さい</option>
+                            ${insertHTML}
+                          </select>
+                        </div>
+                      </div>`;
+    $('.detail-box__category-select').append(childSelectHTML);
+  }
+  // 孫カテゴリー表示のHTML
+  function appendGrandchildrenBox(insertHTML){
+    var grandchildSelectHTML = '';
+    grandchildSelectHtml = `<div class='listing-select-wrapper__added' id= 'grandchildren_wrapper'>
+                              <div class='listing-select-wrapper__box'>
+                                <select class="listing-select-wrapper__box--select" id="grandchild_category" name="item[category_id]">
+                                  <option value="選択して下さい" data-category="選択して下さい">選択して下さい</option>
+                                  ${insertHTML}
+                                </select>
+                              </div>
+                            </div>`;
+    $('.detail-box__category-select').append(grandchildSelectHtml);
+  }
+  // 親カテゴリー選択時
+  $('#parent_category').on('change',function(){
+    var parentCategory = document.getElementById('parent_category').value;
+    if (parentCategory != "選択して下さい"){
+      $.ajax({
+        url: 'get_category_children',
+        type: "GET",
+        data: { parent_name: parentCategory },
+        dataType: 'json'
+      })
+      .done(function(children){
+        $('#children_wrapper').remove();
+        $('#grandchildren_wrapper').remove();
+        var insertHTML = '';
+        children.forEach(function(child){
+          insertHTML += appendOption(child)
+        });
+        appendChildrenBox(insertHTML);
+      })
+      .fail(function(){
+        alert('カテゴリー取得に失敗しました');
+      })
+    }else{
+      $('#children_wrapper').remove();
+      $('#grandchildren_wrapper').remove();
+    }
+  });
+
+  $('.listing-product-detail__category').on('change', '#child_category', function(){
+    var childId = $('#child_category option:selected').data('category');
+    // ここまではOK
+    if (childId != "選択して下さい"){
+      $.ajax({
+        url: 'get_category_grandchildren',
+        type: 'GET',
+        data: { child_id: childId },
+        dataType: 'json'
+      })
+      .done(function(grandchildren){
+        if (grandchildren.length != 0){
+          $('#grandchildren_wrapper').remove();
+          var insertHTML = '';
+          grandchildren.forEach(function(grandchild){
+            insertHTML += appendOption(grandchild);
+          });
+          appendGrandchildrenBox(insertHTML);
+        }
+      })
+      .fail(function(){
+        alert('カテゴリー取得に失敗しました');
+      })
+    }else{
+      $('#grandchildren_wrapper').remove();
+    }
+  });
+});

--- a/app/assets/stylesheets/modules/items/new.scss
+++ b/app/assets/stylesheets/modules/items/new.scss
@@ -43,6 +43,7 @@
   height: 48px;
   padding: 0 56px 0 16px;
   width: 100%;
+  margin-bottom: 10px;
 }
 
 // sale-box__saleの出品する、下書きに保存ボタン文字用
@@ -217,6 +218,9 @@
     &--required {
       @include required
     }
+  }
+  .listing-select-wrapper__box--select{
+    @include select
   }
 
   &__category-select {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :set_category
   before_action :set_item, only:[:show]
   before_action :set_show_instance, only:[:show]
+  before_action :set_sell_instance, only:[:new, :create]
   
   def index
   end
@@ -10,6 +11,14 @@ class ItemsController < ApplicationController
     @item = Item.new
     @item.build_brand
     @item.item_images.build
+  end
+
+  def get_category_children
+    @category_children = Category.find_by(name: "#{params[:parent_name]}", ancestry: nil).children
+  end
+
+  def get_category_grandchildren
+    @category_grandchildren = Category.find("#{params[:child_id]}").children
   end
   
   def create
@@ -47,5 +56,12 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:name, :introduction, :price, [brand_attributes: [:id, :name]], :category_id, :item_condition, :delivery_burden, :delivery_method, :shipper, :shipping_day, :size, {item_images_attributes: [:image, :_destroy, :id]}).merge(seller_id: current_user.id)
+  end
+
+  def set_sell_instance
+    @category_parent_array = ["選択して下さい"]
+    @parents.each do |parent|
+      @category_parent_array << parent.name
+    end
   end
 end

--- a/app/views/items/get_category_children.json.jbuilder
+++ b/app/views/items/get_category_children.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @category_children do |child|
+  json.id child.id
+  json.name child.name
+end

--- a/app/views/items/get_category_grandchildren.json.jbuilder
+++ b/app/views/items/get_category_grandchildren.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @category_grandchildren do |grandchild|
+  json.id grandchild.id
+  json.name grandchild.name
+end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -46,13 +46,15 @@
         .sale-box__guidance
           商品の詳細
         .detail-box
-          .detail-box__category
-            %label
-              カテゴリー
-            %span.detail-box__category--required
-              必須
-          .detail-box__category-select
-            = f.collection_select :category_id, Category.all, :id, :name, prompt: "選択して下さい", class: 'detail-box__category-input'
+          .listing-product-detail__category
+            .detail-box__category
+              %label
+                カテゴリー
+              %span.detail-box__category--required
+                必須
+            .detail-box__category-select
+              -# ここのcategory_idがjsで書き出したフォームと違うcategory_idに登録しようとしているためエラーが発生している
+              = f.select :category_id, @category_parent_array, {}, {class: 'detail-box__category-input', id: 'parent_category'}
           .detail-box__brand
             %label
               ブランド

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -53,7 +53,6 @@
               %span.detail-box__category--required
                 必須
             .detail-box__category-select
-              -# ここのcategory_idがjsで書き出したフォームと違うcategory_idに登録しようとしているためエラーが発生している
               = f.select :category_id, @category_parent_array, {}, {class: 'detail-box__category-input', id: 'parent_category'}
           .detail-box__brand
             %label

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,12 @@
 Rails.application.routes.draw do
   root 'homes#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  resources :items, only: [:index, :new, :show, :create]
+  resources :items, only: [:index, :new, :show, :create] do
+    collection do
+      get 'get_category_children', defaults: { format: 'json' }
+      get 'get_category_grandchildren', defaults: { format: 'json' }
+    end
+  end
   devise_for :users
   resources :profiles, only: [:index, :new, :create, :show, :edit, :update]
   resources :users, only: [:show]


### PR DESCRIPTION
# What
出品ページのカテゴリー選択フォームの実装
# Why
出品時に親、子、孫とカテゴリーを選択できるようにするため
# Supplement
出品機能は前もって実装済みとなっています。
バリデーションに関してもテスト済みで、出品機能実装時と同じ仕様を維持できてます。
（category_idは孫のidが入ります）

![c0415e82ee6f43becf37d7cfedbea9f2](https://user-images.githubusercontent.com/66010511/87417669-7ea67700-c60b-11ea-957c-4cf90cd87ccf.gif)
