### PR TITLE
[WIP]add_buy_check_page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,4 @@
 @import "modules/homes/category-tree";
 @import "modules/credit_cards/new";
 @import "modules/flash";
+@import "modules/purchase/show";

--- a/app/assets/stylesheets/modules/purchase/show.scss
+++ b/app/assets/stylesheets/modules/purchase/show.scss
@@ -1,0 +1,94 @@
+.purchase-show__wrapper{
+  background-color:#f5f5f5;
+  width: 100vw;
+  .body{
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    .item-container{
+      background-color: #fff;
+      max-width: 700px;
+      width: 80%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      .purchase-box{
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 50%;
+        height: 150px;
+        border-bottom: 1px solid #f5f5f5;
+      }
+      .headline-box{
+        h2{
+          font-size: 24px;
+          line-height: 34px;
+          font-weight: bold;
+        }
+      }
+      .purchase-item-box{
+        display: flex;
+        justify-content: space-around;
+        &__image{
+          height: 100px;
+          width: 100px;
+        }
+        &__contents{
+          &--name{
+            max-width: 200px;
+          }
+          &--price{
+            margin-top: 20px;
+            font-size: 12px;
+          }
+        }
+      }
+      .total-place-box{
+        display: flex;
+        justify-content: space-around;
+      }
+      .payment-box{
+        display: flex;
+        justify-content: space-around;
+        font-size: 14px;
+        &--title{
+          span{
+            font-size: 16px;
+          }
+        }
+      }
+      .shipper-box{
+        display: flex;
+        justify-content: space-around;
+        &__contents{
+          display: flex;
+          flex-direction: column;
+          &--address{
+            max-width: 180px;
+            font-size: 12px;
+          }
+        }
+      }
+      .info-box{
+        padding: 0 20px;
+        font-size: 12px;
+        color: lightgrey;
+      }
+      .buy-btn-box{
+        margin: 20px 0;
+        padding: 0 20px;
+        width: 40%;
+        &--submit{
+          text-align: center;
+          line-height: 50px;
+          width: 100%;
+          height: 50px;
+          border-radius: 4px;
+          background-color: rgb(234, 53, 45);
+          color: #fff;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/purchase.scss
+++ b/app/assets/stylesheets/purchase.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the purchase controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -1,0 +1,2 @@
+class PurchaseController < ApplicationController
+end

--- a/app/helpers/purchase_helper.rb
+++ b/app/helpers/purchase_helper.rb
@@ -1,0 +1,2 @@
+module PurchaseHelper
+end

--- a/app/views/purchase/show.html.haml
+++ b/app/views/purchase/show.html.haml
@@ -40,6 +40,7 @@
             香川 洋輔
         .shipper-box__edit-btn
           変更する
+          = icon("fas", "chevron-right")
       .info-box.purchase-box
         郵便局/コンビニ受取をご希望の方は、購入後に取引画面から受取場所を変更をすることが可能です。出品者が発送作業を開始した後は受取場所の変更ができませんので、早めに変更を行ってください。
       =link_to "", class:"buy-btn-box" do

--- a/app/views/purchase/show.html.haml
+++ b/app/views/purchase/show.html.haml
@@ -1,0 +1,49 @@
+.purchase-show__wrapper
+  = render 'profiles/header'
+
+  .body
+    .item-container
+      .headline-box.purchase-box
+        %h2.headline-box__text 購入内容の確認
+      .purchase-item-box.purchase-box
+        = image_tag "pict-reason-03.jpg", class:"purchase-item-box__image"
+        .purchase-item-box__contents
+          .purchase-item-box__contents--name
+            【タイムセール中！】飲みかけのコーヒー
+          .purchase-item-box__contents--price
+            送料込み (税込) 350円
+      .total-place-box.purchase-box
+        .total-place-box--title
+          支払い金額
+        .total-place-box--price
+          ¥350-
+      .payment-box.purchase-box
+        .payment-box--title
+          支払い方法
+          %br
+          %span クレジットカード
+        .payment-box--card
+          ************4242
+          %br
+          有効期限 01/24
+      .shipper-box.purchase-box
+        .shipper-box__contents
+          .shipper-box__contents--title
+            配送先
+          .shipper-box__contents--address
+            〒165-0033
+            %br
+            東京都 中野区 若宮3-19-10
+            %br
+            ATステージ203
+            %br
+            香川 洋輔
+        .shipper-box__edit-btn
+          変更する
+      .info-box.purchase-box
+        郵便局/コンビニ受取をご希望の方は、購入後に取引画面から受取場所を変更をすることが可能です。出品者が発送作業を開始した後は受取場所の変更ができませんので、早めに変更を行ってください。
+      =link_to "", class:"buy-btn-box" do
+        .buy-btn-box--submit
+          購入する
+
+  = render 'profiles/footer'

--- a/app/views/purchase/show.html.haml
+++ b/app/views/purchase/show.html.haml
@@ -33,9 +33,9 @@
           .shipper-box__contents--address
             〒165-0033
             %br
-            東京都 中野区 若宮3-19-10
+            東京都 中野区 超都会9023-38764-1440
             %br
-            ATステージ203
+            めちゃボロアパート102
             %br
             香川 洋輔
         .shipper-box__edit-btn

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,5 @@ Rails.application.routes.draw do
   resources :users, only: [:show]
   resources :categories, only: [:index, :show]
   resources :credit_cards
+  resources :purchase, only: :show
 end

--- a/spec/helpers/purchase_helper_spec.rb
+++ b/spec/helpers/purchase_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PurchaseHelper. For example:
+#
+# describe PurchaseHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PurchaseHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/purchase_request_spec.rb
+++ b/spec/requests/purchase_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Purchases", type: :request do
+
+end


### PR DESCRIPTION
# What
商品購入確認ページの実装
# Why
商品購入時に購入者が商品や支払い方法などの確認を行う必要があるため
<img width="1276" alt="購入確認ページ1" src="https://user-images.githubusercontent.com/66010511/87540399-9a2c8300-c6da-11ea-99c5-527c8dbbe936.png">
<img width="1276" alt="購入確認ページ2" src="https://user-images.githubusercontent.com/66010511/87540661-07401880-c6db-11ea-9fb3-cadf373bf6ca.png">
