### PR TITLE
本番環境のトップページと出品ページの修正

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -2,7 +2,7 @@ class HomesController < ApplicationController
   before_action :set_category
   
   def index
-    @item_images = ItemImage.all
+    @item_images = ItemImage.all.order("created_at DESC").first(4)
     @items = Item.all.order("created_at DESC").first(4)
   end
 

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -12,7 +12,7 @@
               %span.image-box__title--required
                 必須
             %p.image-box__explain
-              最大4枚までアップロードできます
+              最大4枚までアップロードできます（合計画像容量1MBまで）
           .post__drop__box__container
             .prev-content
             .label-content

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,6 +8,7 @@
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application'
     %script{src: "https://js.pay.jp/", type: "text/javascript"}
+    %script{src: "//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"}
   %body
     = render 'layouts/notifications'
     = yield


### PR DESCRIPTION
# What
トップページの画像表示順を最新のものを左側に、出品ページ遷移後すぐにJSが発動しない部分に追加コード。
# Why
商品名と金額のところと画像の表示が違うと利用者を混乱させるから。
出品ページ遷移後に出品がスムーズに行えなければ不便だから。