### PR TITLE
[WIP]add_shipping_address_page

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 |city|string|null: false|
 |street|string|null: false|
 |building_number|string||
-|phone_number|string|null: false|
+|phone_number|string||
 |user|references|null: false, foreign_key: true|
 ### Association
 - belongs_to :user

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,3 +17,4 @@
 @import "modules/credit_cards/show";
 @import "modules/flash";
 @import "modules/purchase/show";
+@import "modules/shipping_address/new_edit";

--- a/app/assets/stylesheets/modules/shipping_address/new_edit.scss
+++ b/app/assets/stylesheets/modules/shipping_address/new_edit.scss
@@ -1,0 +1,143 @@
+@mixin required-label{
+  font-size: 14px;
+  span{
+    padding: 4px;
+    border-radius: 3px;
+    background-color: red;
+    color: #fff;
+  }
+}
+
+@mixin unrequired-label{
+  font-size: 14px;
+  span{
+    padding: 4px;
+    border-radius: 3px;
+    background-color: rgb(194, 194, 194);
+    color: #fff;
+  }
+}
+
+@mixin shipping-address-form{
+  height: 40px;
+  width: 300px;
+  margin: 10px 0;
+  padding-left: 5px;
+}
+
+
+.shipping-address-new__wrapper{
+  background-color: #f3f3f3;
+  .body{
+    display: flex;
+    justify-content: center;
+    .shipping-container{
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      width: 50vw;
+      background-color: #fff;
+      .title-box{
+        border-bottom: 1px solid #f5f5f5;
+        width: 70%;
+        text-align: center;
+        padding: 20px 0;
+        &__text{
+          font-size: 22px;
+          font-weight: bold;
+        }
+      }
+      .shipping-box-sizing{
+        padding: 20px 0 0;
+        display: flex;
+        flex-direction: column;
+      }
+      .name-box{
+        &__label{
+          @include required-label
+        }
+        &__family-name{
+          @include shipping-address-form
+        }
+        &__first-name{
+          @include shipping-address-form
+        }
+      }
+      .kana-name-box{
+        &__label{
+          @include required-label
+        }
+        &__family-name{
+          @include shipping-address-form
+        }
+        &__first-name{
+          @include shipping-address-form
+        }
+      }
+      .postal-code-box{
+        &__label{
+          @include required-label
+        }
+        &__form{
+          @include shipping-address-form
+        }
+      }
+      .state-province-box{
+        &__label{
+          @include required-label
+        }
+        &__form{
+          
+          @include shipping-address-form
+        }
+      }
+      .city-box{
+        &__label{
+          @include required-label
+        }
+        &__form{
+          @include shipping-address-form
+        }
+      }
+      .street-box{
+        &__label{
+          @include required-label
+        }
+        &__form{
+          @include shipping-address-form
+        }
+      }
+      .building-number-box{
+        &__label{
+          @include unrequired-label
+        }
+        &__form{
+          @include shipping-address-form
+        }
+      }
+      .phone-number-box{
+        &__label{
+          @include required-label
+        }
+        &__form{
+          @include shipping-address-form
+        }
+      }
+      .submit-box{
+        padding: 30px 0 20px 0;
+        &__submit-btn{
+          background-color: #3CCACE;
+          color: #fff;
+          width: 200px;
+          height: 50px;
+          border: none;
+          border-radius: 4px;
+          cursor: pointer;
+        }
+      }
+      &__back-btn{
+        margin-bottom: 20px;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/shipping_address/new_edit.scss
+++ b/app/assets/stylesheets/modules/shipping_address/new_edit.scss
@@ -117,7 +117,7 @@
       }
       .phone-number-box{
         &__label{
-          @include required-label
+          @include unrequired-label
         }
         &__form{
           @include shipping-address-form

--- a/app/assets/stylesheets/purchase.scss
+++ b/app/assets/stylesheets/purchase.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the purchase controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/shipping_address_controller.rb
+++ b/app/controllers/shipping_address_controller.rb
@@ -1,0 +1,14 @@
+class ShippingAddressController < ApplicationController
+  
+  
+  def new
+    if current_user.shipping_address.present?
+      redirect_to edit_shipping_address_path(current_user.id)
+    else
+      
+    end
+  end
+
+  def edit
+  end
+end

--- a/app/helpers/shipping_address_helper.rb
+++ b/app/helpers/shipping_address_helper.rb
@@ -1,0 +1,2 @@
+module ShippingAddressHelper
+end

--- a/app/views/shipping_address/edit.html.haml
+++ b/app/views/shipping_address/edit.html.haml
@@ -45,7 +45,7 @@
         .phone-number-box.shipping-box-sizing
           .phone-number-box__label
             %label 電話番号
-            %span 必須
+            %span 任意
           = f.text_field "", placeholder: "例）090-1234-5678", class:"phone-number-box__form"
         .submit-box
           = f.submit "登録する", class:"submit-box__submit-btn"

--- a/app/views/shipping_address/edit.html.haml
+++ b/app/views/shipping_address/edit.html.haml
@@ -1,0 +1,54 @@
+.shipping-address-new__wrapper
+  = render 'profiles/header'
+  .body
+    = form_with model: @shipping_address, local: true do |f|
+      .shipping-container
+        .title-box
+          %h2.title-box__text 発送元・お届け先住所変更
+        .name-box.shipping-box-sizing
+          .name-box__label
+            %label お名前
+            %span 必須
+          = f.text_field "", placeholder: "例）山田", class:"name-box__family-name"
+          = f.text_field "", placeholder: "例）太郎", class:"name-box__first-name"
+        .kana-name-box.shipping-box-sizing
+          .kana-name-box__label
+            %label ふりがな
+            %span 必須
+          = f.text_field "", placeholder: "例）やまだ", class:"kana-name-box__family-name"
+          = f.text_field "", placeholder: "例）たろう", class:"kana-name-box__first-name"
+        .postal-code-box.shipping-box-sizing
+          .postal-code-box__label
+            %label 郵便番号
+            %span 必須
+          = f.number_field "", placeholder: "例）1234567", class:"postal-code-box__form"
+        .state-province-box.shipping-box-sizing
+          .state-province-box__label
+            %label 都道府県
+            %span 必須
+          = f.collection_select :shipping_address, Prefecture.all, :name, :name, {prompt: true}, {class: 'state-province-box__form'}
+        .city-box.shipping-box-sizing
+          .city-box__label
+            %label 市区町村
+            %span 必須
+          = f.text_field "", placeholder: "例）横浜市緑区", class:"city-box__form"
+        .street-box.shipping-box-sizing
+          .street-box__label
+            %label 番地
+            %span 必須
+          = f.text_field "", placeholder: "例）新南1-1-1", class:"street-box__form"
+        .building-number-box.shipping-box-sizing
+          .building-number-box__label
+            %label 建物名・部屋番号
+            %span 任意
+          = f.text_field "", placeholder: "例）フレーム神南坂4F", class:"building-number-box__form"
+        .phone-number-box.shipping-box-sizing
+          .phone-number-box__label
+            %label 電話番号
+            %span 必須
+          = f.text_field "", placeholder: "例）090-1234-5678", class:"phone-number-box__form"
+        .submit-box
+          = f.submit "登録する", class:"submit-box__submit-btn"
+        = link_to user_path(current_user.id),class:"shipping-container__back-btn" do
+          戻る
+  = render 'profiles/footer'

--- a/app/views/shipping_address/new.html.haml
+++ b/app/views/shipping_address/new.html.haml
@@ -45,7 +45,7 @@
         .phone-number-box.shipping-box-sizing
           .phone-number-box__label
             %label 電話番号
-            %span 必須
+            %span 任意
           = f.text_field "", placeholder: "例）090-1234-5678", class:"phone-number-box__form"
         .submit-box
           = f.submit "登録する", class:"submit-box__submit-btn"

--- a/app/views/shipping_address/new.html.haml
+++ b/app/views/shipping_address/new.html.haml
@@ -1,0 +1,54 @@
+.shipping-address-new__wrapper
+  = render 'profiles/header'
+  .body
+    = form_with model: @shipping_address, local: true do |f|
+      .shipping-container
+        .title-box
+          %h2.title-box__text 発送元・お届け先住所登録
+        .name-box.shipping-box-sizing
+          .name-box__label
+            %label お名前
+            %span 必須
+          = f.text_field "", placeholder: "例）山田", class:"name-box__family-name"
+          = f.text_field "", placeholder: "例）太郎", class:"name-box__first-name"
+        .kana-name-box.shipping-box-sizing
+          .kana-name-box__label
+            %label ふりがな
+            %span 必須
+          = f.text_field "", placeholder: "例）やまだ", class:"kana-name-box__family-name"
+          = f.text_field "", placeholder: "例）たろう", class:"kana-name-box__first-name"
+        .postal-code-box.shipping-box-sizing
+          .postal-code-box__label
+            %label 郵便番号
+            %span 必須
+          = f.number_field "", placeholder: "例）1234567", class:"postal-code-box__form"
+        .state-province-box.shipping-box-sizing
+          .state-province-box__label
+            %label 都道府県
+            %span 必須
+          = f.collection_select :shipping_address, Prefecture.all, :name, :name, {prompt: true}, {class: 'state-province-box__form'}
+        .city-box.shipping-box-sizing
+          .city-box__label
+            %label 市区町村
+            %span 必須
+          = f.text_field "", placeholder: "例）横浜市緑区", class:"city-box__form"
+        .street-box.shipping-box-sizing
+          .street-box__label
+            %label 番地
+            %span 必須
+          = f.text_field "", placeholder: "例）新南1-1-1", class:"street-box__form"
+        .building-number-box.shipping-box-sizing
+          .building-number-box__label
+            %label 建物名・部屋番号
+            %span 任意
+          = f.text_field "", placeholder: "例）フレーム神南坂4F", class:"building-number-box__form"
+        .phone-number-box.shipping-box-sizing
+          .phone-number-box__label
+            %label 電話番号
+            %span 必須
+          = f.text_field "", placeholder: "例）090-1234-5678", class:"phone-number-box__form"
+        .submit-box
+          = f.submit "登録する", class:"submit-box__submit-btn"
+        = link_to user_path(current_user.id),class:"shipping-container__back-btn" do
+          戻る
+  = render 'profiles/footer'

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -63,7 +63,7 @@
           %tr
             %td
               .nav-bar-content
-              = link_to "#" do
+              = link_to new_shipping_address_path do
                 住所
               .nav-bar-arrow
                 = icon("fas", "chevron-right")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,5 @@ Rails.application.routes.draw do
   end
   resources :categories, only: [:index, :show]
   resources :purchase, only: :show
+  resources :shipping_address, only: [:new, :edit]
 end

--- a/spec/helpers/shipping_address_helper_spec.rb
+++ b/spec/helpers/shipping_address_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ShippingAddressHelper. For example:
+#
+# describe ShippingAddressHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ShippingAddressHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/shipping_address_request_spec.rb
+++ b/spec/requests/shipping_address_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "ShippingAddresses", type: :request do
+
+end


### PR DESCRIPTION
# What
住所登録/編集画面の実装
# Why
商品購入時に配送先を取得するため
# Supplement
マイページの「設定」→「住所」からリンクに飛べます。
すでに登録がある場合は、変更用ページにリダイレクトさせてます。
サーバーサイド未実装のため、登録済みのデータをフォームに反映はさせていません。