### PR TITLE
[WIP]商品一覧表示の商品画像と商品名・金額の紐付け修正

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -2,8 +2,7 @@ class HomesController < ApplicationController
   before_action :set_category
   
   def index
-    @item_images = ItemImage.all.order("created_at DESC").first(4)
-    @items = Item.all.order("created_at DESC").first(4)
+    @items = Item.all.order("updated_at DESC").limit(4)
   end
 
   private

--- a/app/views/homes/index.html.haml
+++ b/app/views/homes/index.html.haml
@@ -90,24 +90,24 @@
     = link_to '#', class:'pickup-categories__link' do
       新規投稿商品
     .pickup-categories__container
-      - @items.zip(@item_images) do |item, item_image|
+      - @items.each do |item|
         = link_to item_path(item.id), class: 'category-item-box' do
-          = image_tag item_image.image.url, class: 'category-item-box__image'
+          = image_tag item.item_images.first.image.url, class: 'category-item-box__image'
           .category-item-box__name
             = item.name
           .category-item-box__bottom-box
             .category-item-price
-              = item.price 
+              = item.price
               = "円"
               %br
               %span (税込)
             .category-item-favorites
               = icon('fas','star')
               1
-          -if item.buyer_id.present? 
-            .category-item-box-sold
-              .category-item-box-sold__inner
-                SOLD
+            -if item.buyer_id.present? 
+              .category-item-box-sold
+                .category-item-box-sold__inner
+                  SOLD
                 
   .pickup-brand
     .pickup-brand__headline
@@ -115,9 +115,9 @@
     = link_to '#', class: 'pickup-brand__link' do
       アーカイバ
     .pickup-brand__container
-      - @items.zip(@item_images) do |item, item_image|
+      - @items.each do |item|
         = link_to item_path(item.id), class: 'brand-item-box' do
-          = image_tag item_image.image.url, class: 'brand-item-box__image'
+          = image_tag item.item_images.first.image.url, class: 'brand-item-box__image'
           .brand-item-box__name
             = item.name
           .brand-item-box__bottom-box


### PR DESCRIPTION
# What
表題の通り、紐付けが合うようにコードを修正した。
出品時に選択した画像の一番左にあるものが表示される仕様になっている。
# Why
紐付けがしっかりできていないと表示されている画像と商品名・金額が違ってては利用者の混乱を招くから。
# Gif
https://gyazo.com/bcc382c2c0b0913eeeef64a52b8f4f8b