### PR TITLE
fixed_breadcrumb

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,5 +1,8 @@
 = render 'homes/header'
 = render 'homes/sell-btn'
+- breadcrumb :item
+= render "layouts/breadcrumbs"
+
 .main-show
   .item-content
     .item-box

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -39,7 +39,12 @@ crumb :grandchild do |category|
   link "#{category.name}", category_path(category)
   parent :child
 end
-
+# アイテム
+crumb :item do |item|
+  item = Item.find(params[:id])
+  link "#{item.name}", item_path
+  parent :grandchild
+end
 # If you want to split your breadcrumbs configuration over multiple files, you
 # can create a folder named `config/breadcrumbs` and put your configuration
 # files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that


### PR DESCRIPTION
# What
商品詳細ページのパンずく機能実装
# Why
パンくず機能実装時に商品詳細ページに実装していなかったため、追加